### PR TITLE
Example WaveElevation and Surface Velocity Plots

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,10 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)  # In Root, include targe
   target_link_libraries(IncidentWaveExample FreeSurfaceHydrodynamics)
   target_include_directories(IncidentWaveExample PRIVATE ${PROJECT_BINARY_DIR}/include ${gnuplot-iostream_INCLUDE_DIRS})
 
+  add_executable(IncidentWaveDirectionExample examples/IncidentWaveDirectionExample.cpp)
+  target_link_libraries(IncidentWaveDirectionExample FreeSurfaceHydrodynamics)
+  target_include_directories(IncidentWaveDirectionExample PRIVATE ${PROJECT_BINARY_DIR}/include ${gnuplot-iostream_INCLUDE_DIRS})
+
   add_executable(PlotCoeffsExample examples/PlotCoeffsExample.cpp)
   target_link_libraries(PlotCoeffsExample FreeSurfaceHydrodynamics)
   target_include_directories(PlotCoeffsExample PRIVATE ${PROJECT_BINARY_DIR}/include  ${gnuplot-iostream_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.28)
-project(FreeSurfaceHydrodynamics VERSION 1.4.1 LANGUAGES CXX)
+project(FreeSurfaceHydrodynamics VERSION 1.4.2 LANGUAGES CXX)
 
 configure_file(${PROJECT_SOURCE_DIR}/include/FreeSurfaceHydrodynamics/config.h.in
                ${PROJECT_BINARY_DIR}/include/FreeSurfaceHydrodynamics/config.h)

--- a/examples/ExcitingForceExample.cpp
+++ b/examples/ExcitingForceExample.cpp
@@ -125,14 +125,14 @@ int main(int argc, char **argv) {
 
   for (int j = 0; j < 6; j++) { // j denotes direction of resulting force
     std::complex<double> Chi =
-        BuoyA5.WaveExcitingForceComponents(Inc->m_omega[0], j);
+        BuoyA5.WaveExcitingForceComponents(Inc->m_omega.back()[0], j);
     std::vector<double> pts_F_TD, pts_F_FD, pts_eta;
     BuoyA5.SetTimestepSize(dt);
     for (int k = 0; k < pts_t.size(); k++) {
       pts_F_FD.push_back(
-          Inc->m_A[0] * Chi.real() *
+          Inc->m_A.back()[0] * Chi.real() *
               cos(omega * pts_t[k] + phase * cos(180 * M_PI / 180)) -
-          Inc->m_A[0] * Chi.imag() *
+          Inc->m_A.back()[0] * Chi.imag() *
               sin(omega * pts_t[k] + phase * cos(180 * M_PI / 180)));
       pts_eta.push_back(Inc->eta(0, 0, pts_t[k]));
       Eigen::VectorXd ExtForce(6);

--- a/examples/IncidentWaveDirectionExample.cpp
+++ b/examples/IncidentWaveDirectionExample.cpp
@@ -1,0 +1,163 @@
+// Copyright 2022 Monterey Bay Aquarium Research Institute
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Eigen/Dense>
+#include <cstdlib>
+#include <fstream>
+#include <gnuplot-iostream.h>
+#include <iostream>
+#include <vector>
+#include <cstdio>
+#include <cstdlib>
+#include <csignal>
+#include <numeric>
+#include <boost/tuple/tuple.hpp>
+
+#include <FreeSurfaceHydrodynamics/config.h>
+#include <FreeSurfaceHydrodynamics/LinearIncidentWave.hpp>
+
+
+void signal_callback_handler(int signum) {
+  std::string s = "pkill gnuplot_qt";
+  int ret = system(s.c_str());
+  exit(signum);
+}
+
+int main(int argc, char **argv) {
+  {
+    std::string s = "pkill gnuplot_qt";
+    int ret = system(s.c_str());
+  }
+  signal(SIGINT, signal_callback_handler);
+
+  WaveSpectrumType SpectrumType = WaveSpectrumType::MonoChromatic;
+  double A = 1;
+  double T = 12;
+  double phase = 0 * M_PI / 180.0;
+  double beta = 180 * M_PI / 180.0;
+  unsigned int seed = 0;
+
+  int c;
+  while ((c = getopt(argc, argv, "ha:t:p:b:s:S:")) != -1) {
+    switch (c) {
+    case 'a':
+      A = atof(optarg);
+      break;
+    case 't':
+      T = atof(optarg);
+      break;
+    case 'p':
+      phase = atof(optarg)*M_PI/180.0;
+      break;
+    case 'b':
+      beta = atof(optarg)*M_PI/180.0;
+      break;
+    case 's':
+      seed = atof(optarg);
+      break;
+    case 'S':
+      if(*optarg == 'P')
+        SpectrumType = WaveSpectrumType::PiersonMoskowitz;
+      if(*optarg == 'B')
+        SpectrumType = WaveSpectrumType::Bretschneider;
+      if(*optarg == 'C')
+        SpectrumType = WaveSpectrumType::Custom;
+      break;
+    case 'h':
+      std::cout << "Version: " << PROJECT_VER << std::endl;
+      std::cout << "Usage: IncidentWaveExample [-atpbch]" << std::endl;
+      std::cout << " For example:" << std::endl;
+      std::cout << "  [-a 2.0] sets the incident wave amplitude to 2.0 meters" <<std::endl;
+      std::cout << "  [-t -6.0] sets the monochromatic incident wave period to 6.0 seconds" <<std::endl;
+      std::cout << "  [-t 8.0] sets the peak period of an Pierson Moskowitz incident wave to 8.0 seconds" <<std::endl;
+      std::cout << "  [-p 45.0] sets the incident wave phase angle to 45.0 degrees" <<std::endl;
+      std::cout << "  [-b 30.0] sets the incident wave direction to 30.0 degrees" <<std::endl;
+      std::cout << "  [-s 30.0] sets the random seed to 42" <<std::endl;
+      std::cout << "  [-S char] Sets Spectrum, 'M' = MonoChromatic, 'P' = PiersonMoskwitz, 'B' = Bretschneider, 'C' = Custom" <<std::endl;
+      return 0;
+      break;
+    }
+  }
+
+LinearIncidentWave Inc;
+
+if(seed > 0)
+  Inc.SetSeed(seed);
+
+switch (SpectrumType) {
+  case WaveSpectrumType::MonoChromatic :
+      Inc.SetToMonoChromatic(A, T, phase, beta);
+    break;
+  case WaveSpectrumType::PiersonMoskowitz :
+    Inc.SetToPiersonMoskowitzSpectrum(2*A,beta);
+    T = Inc.m_Tp;
+    break;
+  case WaveSpectrumType::Bretschneider :
+      Inc.SetToBretschneiderSpectrum(2*A,T,beta);
+    break;
+  case WaveSpectrumType::Custom :
+    std::vector<double> freq{ 0.029, 0.0341688345, 0.0390, 0.043932892, 0.0488, 0.0536951298, 0.0585, 0.0634555457, 0.0683, 0.0732257700, 0.0781, 0.0829861181, 0.0878, 0.0927488175, 0.0976, 0.102510986, 0.1074, 0.112273223, 0.1171, 0.122035460, 0.1269, 0.131797630, 0.1367, 0.141560329, 0.1464, 0.151320677, 0.1562, 0.161090902, 0.1660, 0.170851250, 0.1757, 0.180613949, 0.1855, 0.190376118, 0.1953, 0.200138288, 0.2050, 0.209900987, 0.2148, 0.219661335, 0.2246, 0.2294315, 0.2343, 0.239191908, 0.2441, 0.248954607, 0.2539, 0.258716776, 0.2636, 0.268479013, 0.2734, 0.278241250, 0.283, 0.288003420, 0.2929, 0.297766119, 0.3027, 0.307460319, 0.312, 0.317483218, 0.3222, 0.326489863, 0.3320, 0.340055272, 0.3515, 0.3655377, 0.3808, 0.395586045, 0.4101, 0.42375818, 0.4394, 0.457258768, 0.4687, 0.473450624, 0.4980, 0.562050220, 0.654, 0.7461795179};
+    std::vector<double> S{0.000999424000, 0.00499205992, 0.00900300, 0.0219735333, 0.03500851, 0.0524594296, 0.07001702, 0.0605521481, 0.05101158, 0.0629676605, 0.0750182, 0.172313322, 0.27056537, 0.65807237, 1.04975564, 1.42013208, 1.7949388, 1.70947731, 1.6228966, 1.27950984, 0.93122764, 0.836434556, 0.74017996, 0.642456728, 0.54313164, 0.469537840, 0.39459635, 0.372046441, 0.34908569, 0.306504292, 0.26306355, 0.222481950, 0.181043, 0.164968711, 0.14853529, 0.138648986, 0.12853043, 0.118648956, 0.10852556, 0.09717288, 0.08552038, 0.0941588507, 0.1030246, 0.0973540982, 0.09152307, 0.0833895727, 0.0750182, 0.067875086, 0.06051430, 0.0592834484, 0.05801369, 0.0557992646, 0.05351219, 0.0503162942, 0.0470118, 0.0457830270, 0.04451123, 0.0418478599, 0.03901030, 0.0341634123, 0.02950758, 0.02950758, 0.02950758, 0.0276578248, 0.0250060, 0.0228586044, 0.02050457, 0.02050457, 0.02050457, 0.0198085867, 0.0190054, 0.0177892797, 0.01700454, 0.0162021945, 0.01200332, 0.00852036595, 0.00350003, 0.001500151916};
+    Inc.SetToCustomSpectrum(freq,S,beta);
+    break;
+}
+
+  double k = pow(2 * M_PI / T, 2) / 9.81;
+  std::cout << Inc << std::endl;
+
+  double dt = .05 * T;
+  double y = 0;
+  for (double t = 0; t <= 4 * dt; t += dt) {
+    char time[10];
+    snprintf(time, sizeof(time), "%.2f", t);
+
+    char outputfilename[64];
+    sprintf(outputfilename, "elev_t%.2f.dat", t);
+
+    char gnuplot_cmd[1024];
+    sprintf(gnuplot_cmd,"splot '%s' w l,'%s' with vectors", outputfilename,outputfilename);
+
+    std::ofstream outputFile(outputfilename);
+
+    double n_wavelengths = 1;
+    int n_divisions = 10;
+
+    for (double x = -(n_wavelengths/2) * 2 * M_PI / k; x <= (n_wavelengths/2) * 2 * M_PI / k; x += (n_wavelengths/n_divisions)*2*M_PI/k) {
+     for (double y = -(n_wavelengths/2) * 2 * M_PI / k; y <= (n_wavelengths/2) * 2 * M_PI / k; y += (n_wavelengths/n_divisions)*2*M_PI/k) {
+      double detadx,detady;
+      double u_east,v_north;
+      double eta = Inc.eta(x,y,t,nullptr,&detady,&u_east,&v_north);
+      double eta_dot = Inc.etadot(x,y,t);
+      outputFile << x << " " << y << " " << eta << " " << 100*u_east << " " << 100*v_north << " " << eta_dot << std::endl;
+     }
+     outputFile << std::endl;
+    }
+    outputFile.close();
+    Gnuplot gp;
+    //gp << "set term qt title  'Incident Wave Elevation at t = " << time
+    //   << " s'\n";
+    gp << "set term qt title  'Incident Wave Elevation at t = " << time
+       << " s'\n";
+    gp << "set grid\n";
+    gp << "set xlabel '(m))'\n";
+    gp << "set ylabel '(m)'\n";
+    gp << "set contour base\n";
+    gp << gnuplot_cmd << std::endl;
+    std::cout << "For interactive plot, use \""  << gnuplot_cmd << "\" in gnuplot from command line" << std::endl;
+  }
+  std::cout << "Enter Ctrl-C to quit.  (Enter 'pkill gnuplot_qt' to clear "
+               "plots if necessary)"
+            << std::endl;
+  while (1);
+}

--- a/examples/IncidentWaveDirectionExample.cpp
+++ b/examples/IncidentWaveDirectionExample.cpp
@@ -103,11 +103,13 @@ switch (SpectrumType) {
   case WaveSpectrumType::PiersonMoskowitz :
     Inc.SetToPiersonMoskowitzSpectrum(2*A,beta);
     Inc.SetToPiersonMoskowitzSpectrum(2*A,beta-45*M_PI/180.0);
+
     T = Inc.m_Tp.back();
     break;
   case WaveSpectrumType::Bretschneider :
-      Inc.SetToBretschneiderSpectrum(2*A,T,beta);
-      Inc.SetToBretschneiderSpectrum(2*A,T,beta-45*M_PI/180.0);
+    //  Inc.SetToBretschneiderSpectrum(2*A,T,beta);
+    //  Inc.SetToBretschneiderSpectrum(2*A,T,beta-45*M_PI/180.0);
+    Inc.SetToBretschneiderSpectrumWithCos2Spreading(2*A,T,beta, 750, 10, 20);
     break;
   case WaveSpectrumType::Custom :
     std::vector<double> freq{ 0.029, 0.0341688345, 0.0390, 0.043932892, 0.0488, 0.0536951298, 0.0585, 0.0634555457, 0.0683, 0.0732257700, 0.0781, 0.0829861181, 0.0878, 0.0927488175, 0.0976, 0.102510986, 0.1074, 0.112273223, 0.1171, 0.122035460, 0.1269, 0.131797630, 0.1367, 0.141560329, 0.1464, 0.151320677, 0.1562, 0.161090902, 0.1660, 0.170851250, 0.1757, 0.180613949, 0.1855, 0.190376118, 0.1953, 0.200138288, 0.2050, 0.209900987, 0.2148, 0.219661335, 0.2246, 0.2294315, 0.2343, 0.239191908, 0.2441, 0.248954607, 0.2539, 0.258716776, 0.2636, 0.268479013, 0.2734, 0.278241250, 0.283, 0.288003420, 0.2929, 0.297766119, 0.3027, 0.307460319, 0.312, 0.317483218, 0.3222, 0.326489863, 0.3320, 0.340055272, 0.3515, 0.3655377, 0.3808, 0.395586045, 0.4101, 0.42375818, 0.4394, 0.457258768, 0.4687, 0.473450624, 0.4980, 0.562050220, 0.654, 0.7461795179};

--- a/examples/IncidentWaveDirectionExample.cpp
+++ b/examples/IncidentWaveDirectionExample.cpp
@@ -101,7 +101,7 @@ switch (SpectrumType) {
     break;
   case WaveSpectrumType::PiersonMoskowitz :
     Inc.SetToPiersonMoskowitzSpectrum(2*A,beta);
-    T = Inc.m_Tp;
+    T = Inc.m_Tp.back();
     break;
   case WaveSpectrumType::Bretschneider :
       Inc.SetToBretschneiderSpectrum(2*A,T,beta);

--- a/examples/IncidentWaveDirectionExample.cpp
+++ b/examples/IncidentWaveDirectionExample.cpp
@@ -98,27 +98,31 @@ if(seed > 0)
 switch (SpectrumType) {
   case WaveSpectrumType::MonoChromatic :
       Inc.SetToMonoChromatic(A, T, phase, beta);
+      Inc.SetToMonoChromatic(A, T, phase, beta-45*M_PI/180.0);
     break;
   case WaveSpectrumType::PiersonMoskowitz :
     Inc.SetToPiersonMoskowitzSpectrum(2*A,beta);
+    Inc.SetToPiersonMoskowitzSpectrum(2*A,beta-45*M_PI/180.0);
     T = Inc.m_Tp.back();
     break;
   case WaveSpectrumType::Bretschneider :
       Inc.SetToBretschneiderSpectrum(2*A,T,beta);
+      Inc.SetToBretschneiderSpectrum(2*A,T,beta-45*M_PI/180.0);
     break;
   case WaveSpectrumType::Custom :
     std::vector<double> freq{ 0.029, 0.0341688345, 0.0390, 0.043932892, 0.0488, 0.0536951298, 0.0585, 0.0634555457, 0.0683, 0.0732257700, 0.0781, 0.0829861181, 0.0878, 0.0927488175, 0.0976, 0.102510986, 0.1074, 0.112273223, 0.1171, 0.122035460, 0.1269, 0.131797630, 0.1367, 0.141560329, 0.1464, 0.151320677, 0.1562, 0.161090902, 0.1660, 0.170851250, 0.1757, 0.180613949, 0.1855, 0.190376118, 0.1953, 0.200138288, 0.2050, 0.209900987, 0.2148, 0.219661335, 0.2246, 0.2294315, 0.2343, 0.239191908, 0.2441, 0.248954607, 0.2539, 0.258716776, 0.2636, 0.268479013, 0.2734, 0.278241250, 0.283, 0.288003420, 0.2929, 0.297766119, 0.3027, 0.307460319, 0.312, 0.317483218, 0.3222, 0.326489863, 0.3320, 0.340055272, 0.3515, 0.3655377, 0.3808, 0.395586045, 0.4101, 0.42375818, 0.4394, 0.457258768, 0.4687, 0.473450624, 0.4980, 0.562050220, 0.654, 0.7461795179};
     std::vector<double> S{0.000999424000, 0.00499205992, 0.00900300, 0.0219735333, 0.03500851, 0.0524594296, 0.07001702, 0.0605521481, 0.05101158, 0.0629676605, 0.0750182, 0.172313322, 0.27056537, 0.65807237, 1.04975564, 1.42013208, 1.7949388, 1.70947731, 1.6228966, 1.27950984, 0.93122764, 0.836434556, 0.74017996, 0.642456728, 0.54313164, 0.469537840, 0.39459635, 0.372046441, 0.34908569, 0.306504292, 0.26306355, 0.222481950, 0.181043, 0.164968711, 0.14853529, 0.138648986, 0.12853043, 0.118648956, 0.10852556, 0.09717288, 0.08552038, 0.0941588507, 0.1030246, 0.0973540982, 0.09152307, 0.0833895727, 0.0750182, 0.067875086, 0.06051430, 0.0592834484, 0.05801369, 0.0557992646, 0.05351219, 0.0503162942, 0.0470118, 0.0457830270, 0.04451123, 0.0418478599, 0.03901030, 0.0341634123, 0.02950758, 0.02950758, 0.02950758, 0.0276578248, 0.0250060, 0.0228586044, 0.02050457, 0.02050457, 0.02050457, 0.0198085867, 0.0190054, 0.0177892797, 0.01700454, 0.0162021945, 0.01200332, 0.00852036595, 0.00350003, 0.001500151916};
     Inc.SetToCustomSpectrum(freq,S,beta);
+    Inc.SetToCustomSpectrum(freq,S,beta-45*M_PI/180.0);
     break;
 }
 
   double k = pow(2 * M_PI / T, 2) / 9.81;
   std::cout << Inc << std::endl;
 
-  double dt = .05 * T;
+  double dt =  T/8;
   double y = 0;
-  for (double t = 0; t <= 4 * dt; t += dt) {
+  for (double t = 0; t <= T; t += dt) {
     char time[10];
     snprintf(time, sizeof(time), "%.2f", t);
 
@@ -130,8 +134,8 @@ switch (SpectrumType) {
 
     std::ofstream outputFile(outputfilename);
 
-    double n_wavelengths = 1;
-    int n_divisions = 10;
+    double n_wavelengths = 5;
+    int n_divisions = 20;
 
     for (double x = -(n_wavelengths/2) * 2 * M_PI / k; x <= (n_wavelengths/2) * 2 * M_PI / k; x += (n_wavelengths/n_divisions)*2*M_PI/k) {
      for (double y = -(n_wavelengths/2) * 2 * M_PI / k; y <= (n_wavelengths/2) * 2 * M_PI / k; y += (n_wavelengths/n_divisions)*2*M_PI/k) {

--- a/examples/IncidentWaveExample.cpp
+++ b/examples/IncidentWaveExample.cpp
@@ -100,7 +100,7 @@ switch (SpectrumType) {
     break;
   case WaveSpectrumType::PiersonMoskowitz :
     Inc.SetToPiersonMoskowitzSpectrum(2*A,beta);
-    T = Inc.m_Tp;
+    T = Inc.m_Tp.back(); //Get the most recent added wave period for plotting purposes
     break;
   case WaveSpectrumType::Bretschneider :
       Inc.SetToBretschneiderSpectrum(2*A,T,beta);
@@ -125,10 +125,10 @@ switch (SpectrumType) {
     std::vector<double> pts_Sw,pts_Sf;
     for(int i = 0;i< Inc.m_omega.size();i++)
     {
-      pts_w.push_back(Inc.m_omega(i));
-      pts_f.push_back(Inc.m_omega(i)/(2.0*M_PI));
-      pts_Sw.push_back(Inc.m_Spectrum(i));
-      pts_Sf.push_back(2.0*M_PI*Inc.m_Spectrum(i));
+      pts_w.push_back(Inc.m_omega.back()(i));
+      pts_f.push_back(Inc.m_omega.back()(i)/(2.0*M_PI));
+      pts_Sw.push_back(Inc.m_Spectrum.back()(i));
+      pts_Sf.push_back(2.0*M_PI*Inc.m_Spectrum.back()(i));
     }
 
 //double sum = std::accumulate(pts_eta.begin(), pts_eta.end(), 0.0);

--- a/examples/IncidentWaveExample.cpp
+++ b/examples/IncidentWaveExample.cpp
@@ -117,6 +117,8 @@ switch (SpectrumType) {
     break;
 }
 
+ std::cout << Inc << std::endl;
+
   double k = pow(2 * M_PI / T, 2) / 9.81;
   std::cout << Inc << std::endl;
 

--- a/fshd_py/cycle.sh.in
+++ b/fshd_py/cycle.sh.in
@@ -2,5 +2,5 @@
 
 rm -r build dist fshd.egg-info
 python3 -m build --wheel
-pip3 uninstall fshd
-pip3 install dist/fshd-@PROJECT_VERSION@-py3-none-any.whl
+pip3 uninstall fshd --break-system-packages
+pip3 install dist/fshd-@PROJECT_VERSION@-py3-none-any.whl --break-system-packages

--- a/fshd_py/fshd/examples/incidentwave.py
+++ b/fshd_py/fshd/examples/incidentwave.py
@@ -8,6 +8,29 @@ import numpy as np
 from fshd import LinearIncidentWave, WaveSpectrumType
 
 
+def spreading_factor_from_spotter_spread_deg(spread_deg):
+    """Convert Spotter/SWIFT first-moment directional spread [deg] to cos^(2s) exponent."""
+    spread_deg = np.asarray(spread_deg, dtype=float)
+    scalar_input = np.ndim(spread_deg) == 0
+
+    max_spread_deg = np.degrees(np.sqrt(2.0))
+
+    if np.any(spread_deg < 0):
+        raise ValueError('spread_deg must be >= 0 (use 0 to disable directional spreading)')
+
+    if np.any(spread_deg[spread_deg > 0] > max_spread_deg):
+        raise ValueError(
+            f'spread_deg must be <= {max_spread_deg:.3f} deg for this mapping'
+        )
+
+    # 0 degrees means no directional spreading; return None for scalar.
+    if scalar_input and spread_deg.item() == 0.0:
+        return None
+
+    spread_rad = np.radians(spread_deg)
+    return int(np.ceil(2.0 / (spread_rad ** 2) - 1.0))
+
+
 _wave_spectrum_type = dict(
     M=WaveSpectrumType.MonoChromatic,
     P=WaveSpectrumType.PiersonMoskowitz,
@@ -27,6 +50,8 @@ def main():
                         help='(degrees) sets the incident wave phase angle')
     parser.add_argument('-b', type=float, default=180.0,
                         help='(degrees) sets the incident wave direction')
+    parser.add_argument('-f', type=int, default=0,
+                        help='(degrees) sets wave spreading (converted to cos2 spreading factor)')
     parser.add_argument('-E', default=None,
                         help='specify json with S and f (spectrum and freq); defaults otherwise')
     parser.add_argument('-s', type=int, default=0,
@@ -59,7 +84,12 @@ def main():
         Inc.SetToPiersonMoskowitzSpectrum(2.*A, beta)
         T = Inc.m_Tp
     elif SpectrumType == WaveSpectrumType.Bretschneider:
-        Inc.SetToBretschneiderSpectrum(2.*A, T, beta)
+        if args.f > 0:
+            sf = spreading_factor_from_spotter_spread_deg(args.f)
+            default_sectors = 20
+            Inc.SetToBretschneiderSpectrumWithCos2Spreading(2.*A, T, beta, sf, default_sectors)
+        else:
+            Inc.SetToBretschneiderSpectrum(2.*A, T, beta)
     elif SpectrumType == WaveSpectrumType.Custom:
         # grav = 9.81
         # w0 = sqrt(0.21 * grav / (2. * A))
@@ -164,14 +194,19 @@ def main():
         pts_eta_true = []
         pts_deta_dx = []
         pts_deta_dy = []
+        pts_u_east = []
+        pts_v_north = []
         for x in np.arange(-1.5 * 2. * np.pi / k,
                            1.5 * 2. * np.pi / k,
                            2.0):
-            eta, deta_dx, deta_dy = Inc.eta(x, y, t, compute_deta=True)
+            eta, deta_dx, deta_dy, u_east, v_north = \
+                Inc.eta(x, y, t, compute_deta=True, compute_uv=True)
             pts_x.append(x)
             pts_eta.append(eta)
             pts_deta_dx.append(deta_dx)
             pts_deta_dy.append(deta_dy)
+            pts_u_east.append(u_east)
+            pts_v_north.append(v_north)
 
             xx = x * np.cos(beta) + y * np.sin(beta)
             pts_eta_true.append(A * np.cos(k * xx - 2. * np.pi * t / T + phase))
@@ -193,6 +228,31 @@ def main():
         ax2.tick_params(axis='y', labelcolor=color)
 
         lns = ln1 + ln2 + ln3
+        labs = [l.get_label() for l in lns]
+        ax.legend(lns, labs, loc=1)
+
+        fig.suptitle(f'Incident Wave Elevation at {t = :.2f} (s)')
+        fig.tight_layout()
+
+        fig, ax = plt.subplots(1)
+
+        color = 'tab:red'
+        ln1 = ax.plot(pts_x, pts_eta, 'r', label='eta (m)')
+        ax.set_ylabel('meters', color=color)
+        ax.tick_params(axis='y', labelcolor=color)
+        ax.set_xlabel('meters')
+
+        ln2 = ax.plot(pts_x, pts_eta_true, '--g', label='eta true (m)')
+
+        color = 'tab:blue'
+        ax2 = ax.twinx()
+        ln3 = ax2.plot(pts_x, pts_u_east, 'b', label='u (east) (m/s)')
+        ax2.set_ylabel('meters per sec', color=color)
+        ax2.tick_params(axis='y', labelcolor=color)
+
+        ln4 = ax2.plot(pts_x, pts_v_north, 'g', label='v (north) (m/s)')
+
+        lns = ln1 + ln2 + ln3 + ln4
         labs = [l.get_label() for l in lns]
         ax.legend(lns, labs, loc=1)
 

--- a/fshd_py/fshd/examples/incidentwave.py
+++ b/fshd_py/fshd/examples/incidentwave.py
@@ -78,15 +78,20 @@ def main():
     if seed > 0:
         Inc.SetSeed(seed)
 
+    sf = spreading_factor_from_spotter_spread_deg(args.f)
+    default_sectors = 20
     if SpectrumType == WaveSpectrumType.MonoChromatic:
         Inc.SetToMonoChromatic(A, T, phase, beta)
     elif SpectrumType == WaveSpectrumType.PiersonMoskowitz:
-        Inc.SetToPiersonMoskowitzSpectrum(2.*A, beta)
-        T = Inc.m_Tp
-    elif SpectrumType == WaveSpectrumType.Bretschneider:
+        print("setting pierson moskowitz")
         if args.f > 0:
-            sf = spreading_factor_from_spotter_spread_deg(args.f)
-            default_sectors = 20
+            Inc.SetToPiersonMoskowitzSpectrumWithCos2Spreading(2.*A, beta, sf, default_sectors)
+        else:
+            Inc.SetToPiersonMoskowitzSpectrum(2.*A, beta)
+        T = 2.0 * np.pi * np.sqrt(2. * A / 9.81) / 0.4019
+    elif SpectrumType == WaveSpectrumType.Bretschneider:
+        print("setting bretschneider")
+        if args.f > 0:
             Inc.SetToBretschneiderSpectrumWithCos2Spreading(2.*A, T, beta, sf, default_sectors)
         else:
             Inc.SetToBretschneiderSpectrum(2.*A, T, beta)

--- a/fshd_py/fshd/examples/incidentwave.py
+++ b/fshd_py/fshd/examples/incidentwave.py
@@ -50,11 +50,11 @@ def main():
                         help='(degrees) sets the incident wave phase angle')
     parser.add_argument('-b', type=float, default=180.0,
                         help='(degrees) sets the incident wave direction')
-    parser.add_argument('-f', type=int, default=0,
+    parser.add_argument('-s', type=int, default=0,
                         help='(degrees) sets wave spreading (converted to cos2 spreading factor)')
     parser.add_argument('-E', default=None,
                         help='specify json with S and f (spectrum and freq); defaults otherwise')
-    parser.add_argument('-s', type=int, default=0,
+    parser.add_argument('-r', type=int, default=0,
                         help='sets the random seed')
     parser.add_argument('-S', type=str, default='M',
                         choices=['M', 'P', 'B', 'C'],
@@ -63,6 +63,11 @@ def main():
                                  + ", 'P'iersonMoskowitz" \
                                  + ", 'B'retschneider" \
                                  + ", 'C'ustom")
+    parser.add_argument('-o', type=str, default=None,
+                        help='output netcdf filename with incident wave data. Skips plotting.')
+    parser.add_argument('-n', type=int, default=10,
+                        help='for output, number of wave periods to save')
+
     args = parser.parse_args()
 
     SpectrumType = _wave_spectrum_type[args.S]
@@ -70,7 +75,7 @@ def main():
     T = args.t
     phase = args.p * np.pi / 180.0
     beta = args.b * np.pi / 180.0
-    seed = args.s
+    seed = args.r
 
 
     Inc = LinearIncidentWave()
@@ -78,20 +83,20 @@ def main():
     if seed > 0:
         Inc.SetSeed(seed)
 
-    sf = spreading_factor_from_spotter_spread_deg(args.f)
+    sf = spreading_factor_from_spotter_spread_deg(args.s)
     default_sectors = 20
     if SpectrumType == WaveSpectrumType.MonoChromatic:
         Inc.SetToMonoChromatic(A, T, phase, beta)
     elif SpectrumType == WaveSpectrumType.PiersonMoskowitz:
         print("setting pierson moskowitz")
-        if args.f > 0:
+        if args.s > 0:
             Inc.SetToPiersonMoskowitzSpectrumWithCos2Spreading(2.*A, beta, sf, default_sectors)
         else:
             Inc.SetToPiersonMoskowitzSpectrum(2.*A, beta)
         T = 2.0 * np.pi * np.sqrt(2. * A / 9.81) / 0.4019
     elif SpectrumType == WaveSpectrumType.Bretschneider:
         print("setting bretschneider")
-        if args.f > 0:
+        if args.s > 0:
             Inc.SetToBretschneiderSpectrumWithCos2Spreading(2.*A, T, beta, sf, default_sectors)
         else:
             Inc.SetToBretschneiderSpectrum(2.*A, T, beta)
@@ -166,6 +171,38 @@ def main():
     k = ((2. * np.pi / T)**2.) / 9.81
     # print(Inc)
 
+    if args.o is not None:
+        import xarray as xr
+        pts_t = []
+        pts_eta = []
+        pts_deta_dx = []
+        pts_deta_dy = []
+        pts_u_east = []
+        pts_v_north = []
+        for t in np.arange(0., args.n*T, 0.1):
+            pts_t.append(t)
+            eta, deta_dx, deta_dy, u_east, v_north = \
+                Inc.eta(0., 0., t, compute_deta=True, compute_uv=True)
+            pts_eta.append(eta)
+            pts_deta_dx.append(deta_dx)
+            pts_deta_dy.append(deta_dy)
+            pts_u_east.append(u_east)
+            pts_v_north.append(v_north)
+        ds = xr.Dataset(
+                data_vars={
+                    'eta': (['time'], pts_eta),
+                    'deta_dx': (['time'], pts_deta_dx),
+                    'deta_dy': (['time'], pts_deta_dy),
+                    'u_east': (['time'], pts_u_east),
+                    'v_north': (['time'], pts_v_north),
+                },
+                coords={
+                    'time': pts_t,
+                },
+            )
+        ds.to_netcdf(args.o)
+        import sys; sys.exit(0)
+
     # plot
     pts_t = []
     pts_eta = []
@@ -178,7 +215,6 @@ def main():
         eta = Inc.eta(x, y, t)
         pts_eta.append(eta)
         pts_eta_true.append(A * np.cos(k * xx - 2. * np.pi * t / T + phase))
-
 
     fig, ax = plt.subplots(1)
 
@@ -241,27 +277,44 @@ def main():
 
         fig, ax = plt.subplots(1)
 
-        color = 'tab:red'
-        ln1 = ax.plot(pts_x, pts_eta, 'r', label='eta (m)')
-        ax.set_ylabel('meters', color=color)
-        ax.tick_params(axis='y', labelcolor=color)
-        ax.set_xlabel('meters')
-
-        ln2 = ax.plot(pts_x, pts_eta_true, '--g', label='eta true (m)')
-
-        color = 'tab:blue'
-        ax2 = ax.twinx()
-        ln3 = ax2.plot(pts_x, pts_u_east, 'b', label='u (east) (m/s)')
-        ax2.set_ylabel('meters per sec', color=color)
+        ln1 = ax.plot(pts_u_east, pts_v_north, 'b', label='u/v cycles (m/s)')
+        ax2.set_xlabel('u_east', color=color)
+        ax2.set_ylabel('v_north', color=color)
         ax2.tick_params(axis='y', labelcolor=color)
 
-        ln4 = ax2.plot(pts_x, pts_v_north, 'g', label='v (north) (m/s)')
-
-        lns = ln1 + ln2 + ln3 + ln4
+        lns = ln1
         labs = [l.get_label() for l in lns]
         ax.legend(lns, labs, loc=1)
 
-        fig.suptitle(f'Incident Wave Elevation at {t = :.2f} (s)')
+        fig.suptitle(f'Incident Wave u/v cycles at {t = :.2f} (s)')
+        fig.tight_layout()
+
+        fig, ax = plt.subplots(1)
+
+        ln1 = ax.plot(pts_u_east, pts_deta_dx, 'b', label='u/deta cycles (m/s)')
+        ax2.set_xlabel('u_east', color=color)
+        ax2.set_ylabel('deta', color=color)
+        ax2.tick_params(axis='y', labelcolor=color)
+
+        lns = ln1
+        labs = [l.get_label() for l in lns]
+        ax.legend(lns, labs, loc=1)
+
+        fig.suptitle(f'Incident Wave u vs deta cycles at {t = :.2f} (s)')
+        fig.tight_layout()
+
+        fig, ax = plt.subplots(1)
+
+        ln1 = ax.plot(pts_v_north, pts_deta_dy, 'b', label='v/deta cycles (m/s)')
+        ax2.set_xlabel('u_east', color=color)
+        ax2.set_ylabel('deta', color=color)
+        ax2.tick_params(axis='y', labelcolor=color)
+
+        lns = ln1
+        labs = [l.get_label() for l in lns]
+        ax.legend(lns, labs, loc=1)
+
+        fig.suptitle(f'Incident Wave v vs deta cycles at {t = :.2f} (s)')
         fig.tight_layout()
 
     plt.show()

--- a/include/FreeSurfaceHydrodynamics/LinearIncidentWave.hpp
+++ b/include/FreeSurfaceHydrodynamics/LinearIncidentWave.hpp
@@ -50,6 +50,7 @@ public:
   void SetToPiersonMoskowitzSpectrum(double Hs, double UnusedTp, double beta, int n_phases);
   void SetToBretschneiderSpectrum(double Hs, double Tp, double beta);
   void SetToBretschneiderSpectrum(double Hs, double Tp, double beta, int n_phases);
+  void SetToBretschneiderSpectrumWithCos2Spreading(double Hs, double Tp, double beta, int n_phases,int spreading_factor, int n_sectors);
   void SetToCustomSpectrum(std::vector<double> freq, std::vector<double> S, double beta);
   void SetToCustomSpectrum(std::vector<double> freq, std::vector<double> S, double beta, int n_phases);
   friend std::ostream & operator<<(std::ostream & out, const LinearIncidentWave & IncWave);

--- a/include/FreeSurfaceHydrodynamics/LinearIncidentWave.hpp
+++ b/include/FreeSurfaceHydrodynamics/LinearIncidentWave.hpp
@@ -48,8 +48,11 @@ public:
   void SetToPiersonMoskowitzSpectrum(double Hs, double beta, int n_phases);
   void SetToPiersonMoskowitzSpectrum(double Hs, double UnusedTp, double beta);
   void SetToPiersonMoskowitzSpectrum(double Hs, double UnusedTp, double beta, int n_phases);
+  void SetToPiersonMoskowitzSpectrumWithCos2Spreading(double Hs, double beta, int n_phases,int spreading_factor, int n_sectors);
+  void SetToPiersonMoskowitzSpectrumWithCos2Spreading(double Hs, double beta, int spreading_factor, int n_sectors);
   void SetToBretschneiderSpectrum(double Hs, double Tp, double beta);
   void SetToBretschneiderSpectrum(double Hs, double Tp, double beta, int n_phases);
+  void SetToBretschneiderSpectrumWithCos2Spreading(double Hs, double Tp, double beta, int spreading_factor, int n_sectors);
   void SetToBretschneiderSpectrumWithCos2Spreading(double Hs, double Tp, double beta, int n_phases,int spreading_factor, int n_sectors);
   void SetToCustomSpectrum(std::vector<double> freq, std::vector<double> S, double beta);
   void SetToCustomSpectrum(std::vector<double> freq, std::vector<double> S, double beta, int n_phases);

--- a/include/FreeSurfaceHydrodynamics/LinearIncidentWave.hpp
+++ b/include/FreeSurfaceHydrodynamics/LinearIncidentWave.hpp
@@ -74,9 +74,9 @@ public:
   std::vector<Eigen::VectorXd> m_omega;
   std::vector<Eigen::VectorXd> m_k;
   std::vector<Eigen::VectorXd> m_phases;
-  std::vector<double> m_beta{0.};
-  std::vector<double> m_Hs{1.};
-  std::vector<double> m_Tp{10.};
+  std::vector<double> m_beta;
+  std::vector<double> m_Hs;
+  std::vector<double> m_Tp;
 };
 
 #endif  // FREESURFACEHYDRODYNAMICS__LIB__LINEARINCIDENTWAVE_HPP_

--- a/include/FreeSurfaceHydrodynamics/LinearIncidentWave.hpp
+++ b/include/FreeSurfaceHydrodynamics/LinearIncidentWave.hpp
@@ -65,18 +65,18 @@ public:
   int PatchVersionNumber();
 
 public:
-  WaveSpectrumType m_SpectrumType = WaveSpectrumType::MonoChromatic;
   double m_grav{9.81};
   double m_rho{1025.};
-  Eigen::VectorXd m_Spectrum;
-  Eigen::VectorXd m_A;
-  Eigen::VectorXd m_omega;
-  Eigen::VectorXd m_k;
-  Eigen::VectorXd m_phases;
-  double m_beta{0.};
-  double m_Hs{1.};
-  double m_Tp{10.};
-  std::vector<Eigen::Matrix<double, Eigen::Dynamic, 1>> fd_Pha_Xi;
+  int NumWaveComponents{0};
+  std::vector<WaveSpectrumType> m_SpectrumType;
+  std::vector<Eigen::VectorXd> m_Spectrum;
+  std::vector<Eigen::VectorXd> m_A;
+  std::vector<Eigen::VectorXd> m_omega;
+  std::vector<Eigen::VectorXd> m_k;
+  std::vector<Eigen::VectorXd> m_phases;
+  std::vector<double> m_beta{0.};
+  std::vector<double> m_Hs{1.};
+  std::vector<double> m_Tp{10.};
 };
 
 #endif  // FREESURFACEHYDRODYNAMICS__LIB__LINEARINCIDENTWAVE_HPP_

--- a/src/LinearIncidentWave.cpp
+++ b/src/LinearIncidentWave.cpp
@@ -74,6 +74,11 @@ void LinearIncidentWave::SetToBretschneiderSpectrum(double Hs, double Tp, double
   SetToBretschneiderSpectrum(Hs, Tp, beta, DEFAULT_N_PHASES);
 }
 
+void LinearIncidentWave::SetToBretschneiderSpectrumWithCos2Spreading(double Hs, double Tp, double beta_0, int spreading_factor, int n_sectors)
+{
+  SetToBretschneiderSpectrumWithCos2Spreading(Hs, Tp, beta_0, DEFAULT_N_PHASES, spreading_factor, n_sectors);
+}
+
 void LinearIncidentWave::SetToBretschneiderSpectrumWithCos2Spreading(double Hs, double Tp, double beta_0, int n_phases,int spreading_factor, int n_sectors)
 {
 double d_beta = 2.0*M_PI/n_sectors;
@@ -119,6 +124,22 @@ void LinearIncidentWave::SetToBretschneiderSpectrum(
   NumWaveComponents++;  // Adding a wave component
 }
 
+
+void LinearIncidentWave::SetToPiersonMoskowitzSpectrumWithCos2Spreading(double Hs, double beta_0, int spreading_factor, int n_sectors)
+{
+  SetToPiersonMoskowitzSpectrumWithCos2Spreading(Hs, beta_0, DEFAULT_N_PHASES, spreading_factor, n_sectors);
+}
+
+void LinearIncidentWave::SetToPiersonMoskowitzSpectrumWithCos2Spreading(double Hs, double beta_0, int n_phases,int spreading_factor, int n_sectors)
+{
+double d_beta = 2.0*M_PI/n_sectors;
+for(int n = 1; n < n_sectors; n++) // start with n = 1 b/c the reciprocal heading wave is of identically zero  (cos(pi/2) = 0)
+  {
+  double beta = beta_0-(n*d_beta-M_PI);
+  double D = std::pow(cos((beta-beta_0)/2),2*spreading_factor)*std::tgamma(1.0+spreading_factor)/(2*sqrt(M_PI)*std::tgamma(0.5+spreading_factor));
+  SetToPiersonMoskowitzSpectrum(Hs*sqrt(D), beta, n_phases); // Spectrum energy scales as the square of Hs, so sqrt(D) introduces a factor of D into the Spectrum
+  }
+}
 
 /// \brief Select PM-Spectrum (default num of phases)  
 /// [DEPRECATED - This version including the unused Tp specificatoin may be removed in the future]

--- a/src/LinearIncidentWave.cpp
+++ b/src/LinearIncidentWave.cpp
@@ -141,14 +141,14 @@ for(int n = 1; n < n_sectors; n++) // start with n = 1 b/c the reciprocal headin
   }
 }
 
-/// \brief Select PM-Spectrum (default num of phases)  
+/// \brief Select PM-Spectrum (default num of phases)
 /// [DEPRECATED - This version including the unused Tp specificatoin may be removed in the future]
 void LinearIncidentWave::SetToPiersonMoskowitzSpectrum(double Hs, double UnusedTp, double beta)
 {
   SetToPiersonMoskowitzSpectrum(Hs, beta, DEFAULT_N_PHASES);
 }
 
-/// \brief Select PM-Spectrum (set num of phases) 
+/// \brief Select PM-Spectrum (set num of phases)
 /// [DEPRECATED - This version including the unused Tp specificatoin may be removed in the future]
 void LinearIncidentWave::SetToPiersonMoskowitzSpectrum(
  double Hs, double UnusedTp, double beta, int n_phases)
@@ -157,13 +157,13 @@ void LinearIncidentWave::SetToPiersonMoskowitzSpectrum(
  }
 
 
-/// \brief Select PM-Spectrum (default num of phases)  
+/// \brief Select PM-Spectrum (default num of phases)
 void LinearIncidentWave::SetToPiersonMoskowitzSpectrum(double Hs, double beta)
 {
   SetToPiersonMoskowitzSpectrum(Hs, beta, DEFAULT_N_PHASES);
 }
 
-/// \brief Select PM-Spectrum (set num of phases) 
+/// \brief Select PM-Spectrum (set num of phases)
 void LinearIncidentWave::SetToPiersonMoskowitzSpectrum(
   double Hs, double beta, int n_phases)
 {
@@ -245,7 +245,7 @@ std::ostream & operator<<(std::ostream & out, const LinearIncidentWave & IncWave
   std::cout << "# IncidentWave consists of " << IncWave.NumWaveComponents << " Components" << std::endl;
   for(int n = 0; n< IncWave.NumWaveComponents;n++)
   {
-  switch (IncWave.m_SpectrumType[IncWave.NumWaveComponents]) {
+  switch (IncWave.m_SpectrumType[n]) {
     case WaveSpectrumType::MonoChromatic:
       std::cout << "# IncidentWave Type = Mono-Chromatic" << std::endl;
       std::cout << "# Amplitude = " << IncWave.m_Hs[n] / 2 << std::endl;

--- a/src/LinearIncidentWave.cpp
+++ b/src/LinearIncidentWave.cpp
@@ -74,6 +74,19 @@ void LinearIncidentWave::SetToBretschneiderSpectrum(double Hs, double Tp, double
   SetToBretschneiderSpectrum(Hs, Tp, beta, DEFAULT_N_PHASES);
 }
 
+void LinearIncidentWave::SetToBretschneiderSpectrumWithCos2Spreading(double Hs, double Tp, double beta_0, int n_phases,int spreading_factor, int n_sectors)
+{
+double d_beta = 2.0*M_PI/n_sectors;
+for(int n = 1; n < n_sectors; n++) // start with n = 1 b/c the reciprocal heading wave is of identically zero  (cos(pi/2) = 0)
+  {
+  double beta = beta_0-(n*d_beta-M_PI);
+  double D = std::pow(cos((beta-beta_0)/2),2*spreading_factor)*std::tgamma(1.0+spreading_factor)/(2*sqrt(M_PI)*std::tgamma(0.5+spreading_factor));
+  //std::cout << "n = "  << n << "  beta = " << beta*180/M_PI << "  beta-beta_0 = " << beta-beta_0 << "  D " << D << std::endl;
+  SetToBretschneiderSpectrum(Hs*sqrt(D), Tp, beta, n_phases); // Spectrum energy scales as the square of Hs, so sqrt(D) introduces a factor of D into the Spectrum
+  }
+}
+
+
 /// \brief Select Bretschneider Spectrum (set num of phases)
 void LinearIncidentWave::SetToBretschneiderSpectrum(
   double Hs, double Tp, double beta,

--- a/src/LinearIncidentWave.cpp
+++ b/src/LinearIncidentWave.cpp
@@ -50,19 +50,22 @@ void LinearIncidentWave::SetSeed(unsigned int seed)
 void LinearIncidentWave::SetToMonoChromatic(double A, double T, double phase, double beta)
 {
   std::cout << "Mono A = " << A << std::endl;
-  m_SpectrumType = WaveSpectrumType::MonoChromatic;
-  m_Hs = 2 * A;
-  m_Tp = T;
-  m_beta = beta;
-  m_omega.resize(1);
-  m_k.resize(1);
-  m_phases.resize(1);
-  m_Spectrum.resize(1);
-  m_A.resize(1);
-  m_phases(0) = phase;
-  m_omega(0) = 2 * M_PI / T;
-  m_k(0) = m_omega(0) * m_omega(0) / m_grav;
-  m_A(0) = A;
+
+  m_SpectrumType.push_back(WaveSpectrumType::MonoChromatic);
+  m_Hs.push_back(2 * A);
+  m_Tp.push_back(T);
+  m_beta.push_back(beta);
+  Eigen::VectorXd tmp_array(1);  // Create array and push a copy and put a copy in each relevant std::vector
+  m_omega.push_back(tmp_array);
+  m_k.push_back(tmp_array);
+  m_phases.push_back(tmp_array);
+  m_Spectrum.push_back(tmp_array);
+  m_A.push_back(tmp_array);
+  m_phases[NumWaveComponents](0) = phase;
+  m_omega[NumWaveComponents](0) = 2 * M_PI / T;
+  m_k[NumWaveComponents](0) = (2*M_PI/T)*(2*M_PI/T)/m_grav;
+  m_A[NumWaveComponents](0) = A;
+  NumWaveComponents++;  // Adding a wave component
 }
 
 /// \brief Select PM-Spectrum (default num of phases)
@@ -76,30 +79,31 @@ void LinearIncidentWave::SetToBretschneiderSpectrum(
   double Hs, double Tp, double beta,
   int n_phases)
 {
-  m_SpectrumType = WaveSpectrumType::Bretschneider;
-  m_beta = beta;
-  m_Hs = Hs;
-  
+  m_SpectrumType.push_back(WaveSpectrumType::Bretschneider);
+  m_Hs.push_back(Hs);
+  m_Tp.push_back(Tp);
+  m_beta.push_back(beta);
+  Eigen::VectorXd tmp_array(n_phases);  // Create array and push a copy and put a copy in each relevant std::vector
+  m_omega.push_back(tmp_array);
+  m_k.push_back(tmp_array);
+  m_phases.push_back(tmp_array);
+  m_Spectrum.push_back(tmp_array);
+  m_A.push_back(tmp_array);
+
   double wp = 2.0*M_PI/(1.2957*Tp);
-
-  m_omega.resize(n_phases);
-  m_k.resize(n_phases);
-  m_phases.resize(n_phases);
-  m_Spectrum.resize(n_phases);
-  m_A.resize(n_phases);
-
   double d_omega = MAX_FREQ * 2 * M_PI / n_phases;
 
-  for (int i = 0; i < m_k.size(); i++) {
-    m_omega(i) = d_omega * (i + 1) + (0.25*d_omega*(std::rand()-RAND_MAX/2))/(RAND_MAX/2);
-    m_k(i) = m_omega(i) * m_omega(i) / m_grav;
-    m_Spectrum(i) = 5.0*Hs*Hs*pow(wp,4) * exp(-1.25*pow(wp/m_omega(i),4)) / (16.0*pow(m_omega(i),5));
+  for (int i = 0; i < m_k[NumWaveComponents].size(); i++) {
+    m_omega[NumWaveComponents](i) = d_omega * (i + 1) + (0.25*d_omega*(std::rand()-RAND_MAX/2))/(RAND_MAX/2);
+    m_k[NumWaveComponents](i) = m_omega[NumWaveComponents](i) * m_omega[NumWaveComponents](i) / m_grav;
+    m_Spectrum[NumWaveComponents](i) = 5.0*Hs*Hs*pow(wp,4) * exp(-1.25*pow(wp/m_omega[NumWaveComponents](i),4)) / (16.0*pow(m_omega[NumWaveComponents](i),5));
     if(i == 0)
-      m_A(i) = sqrt(2.0*m_omega(0) * m_Spectrum(i));  // Precompute components once here.
+      m_A[NumWaveComponents](i) = sqrt(2.0*m_omega[NumWaveComponents](0) * m_Spectrum[NumWaveComponents](i));  // Precompute components once here.
     else
-      m_A(i) = sqrt(2.0*(m_omega(i)-m_omega(i-1)) * m_Spectrum(i));  // Precompute components once here.
-    m_phases(i) = (2 * M_PI * std::rand()) / RAND_MAX;
+      m_A[NumWaveComponents](i) = sqrt(2.0*(m_omega[NumWaveComponents](i)-m_omega[NumWaveComponents](i-1)) * m_Spectrum[NumWaveComponents](i));  // Precompute components once here.
+    m_phases[NumWaveComponents](i) = (2 * M_PI * std::rand()) / RAND_MAX;
   }
+  NumWaveComponents++;  // Adding a wave component
 }
 
 
@@ -129,16 +133,16 @@ void LinearIncidentWave::SetToPiersonMoskowitzSpectrum(double Hs, double beta)
 void LinearIncidentWave::SetToPiersonMoskowitzSpectrum(
   double Hs, double beta, int n_phases)
 {
-  m_SpectrumType = WaveSpectrumType::PiersonMoskowitz;
-  m_beta = beta;
-  m_Hs = Hs;
-  m_Tp = 2*M_PI*sqrt(m_Hs/m_grav)/0.4019;
-
-  m_omega.resize(n_phases);
-  m_k.resize(n_phases);
-  m_phases.resize(n_phases);
-  m_Spectrum.resize(n_phases);
-  m_A.resize(n_phases);
+  m_SpectrumType.push_back(WaveSpectrumType::PiersonMoskowitz);
+  m_Hs.push_back(Hs);
+  m_Tp.push_back(2*M_PI*sqrt(Hs/m_grav)/0.4019);
+  m_beta.push_back(beta);
+  Eigen::VectorXd tmp_array(n_phases);  // Create array and push a copy and put a copy in each relevant std::vector
+  m_omega.push_back(tmp_array);
+  m_k.push_back(tmp_array);
+  m_phases.push_back(tmp_array);
+  m_Spectrum.push_back(tmp_array);
+  m_A.push_back(tmp_array);
 
   double w0 = sqrt(.21 * m_grav / Hs);
   double a = 0.0081;
@@ -146,16 +150,17 @@ void LinearIncidentWave::SetToPiersonMoskowitzSpectrum(
 
   double d_omega = MAX_FREQ * 2 * M_PI / n_phases;
 
-  for (int i = 0; i < m_k.size(); i++) {
-    m_omega(i) = d_omega * (i + 1) + (0.25*d_omega*(std::rand()-RAND_MAX/2))/(RAND_MAX/2);
-    m_k(i) = m_omega(i) * m_omega(i) / m_grav;
-    m_Spectrum(i) = (a * m_grav * m_grav / pow(m_omega(i), 5)) * exp(-b * pow(w0 / m_omega(i), 4));
+  for (int i = 0; i < m_k[NumWaveComponents].size(); i++) {
+    m_omega[NumWaveComponents](i) = d_omega * (i + 1) + (0.25*d_omega*(std::rand()-RAND_MAX/2))/(RAND_MAX/2);
+    m_k[NumWaveComponents](i) = m_omega[NumWaveComponents](i) * m_omega[NumWaveComponents](i) / m_grav;
+    m_Spectrum[NumWaveComponents](i) = (a * m_grav * m_grav / pow(m_omega[NumWaveComponents](i), 5)) * exp(-b * pow(w0 / m_omega[NumWaveComponents](i), 4));
     if(i == 0)
-      m_A(i) = sqrt(2.0*m_omega(0) * m_Spectrum(i));  // Precompute components once here.
+      m_A[NumWaveComponents](i) = sqrt(2.0*m_omega[NumWaveComponents](0) * m_Spectrum[NumWaveComponents](i));  // Precompute components once here.
     else
-      m_A(i) = sqrt(2.0*(m_omega(i)-m_omega(i-1)) * m_Spectrum(i));  // Precompute components once here.
-    m_phases(i) = (2 * M_PI * std::rand()) / RAND_MAX;
+      m_A[NumWaveComponents](i) = sqrt(2.0*(m_omega[NumWaveComponents](i)-m_omega[NumWaveComponents](i-1)) * m_Spectrum[NumWaveComponents](i));  // Precompute components once here.
+    m_phases[NumWaveComponents](i) = (2 * M_PI * std::rand()) / RAND_MAX;
   }
+  NumWaveComponents++;  // Adding a wave component
 }
 
 /// \brief Specify Custom Spectrum (default num of phases)
@@ -171,88 +176,98 @@ void LinearIncidentWave::SetToCustomSpectrum(std::vector<double> freq, std::vect
 
   simple_interp::Interp1d CustomSpectrum(freq,S);  // Subsequent calculations are done in ang freq
 
-  m_SpectrumType = WaveSpectrumType::Custom;
-  m_beta = beta;
-
-  m_omega.resize(n_phases);
-  m_k.resize(n_phases);
-  m_phases.resize(n_phases);
-  m_Spectrum.resize(n_phases);
-  m_A.resize(n_phases);
+  m_SpectrumType.push_back(WaveSpectrumType::Custom);
+  m_Hs.push_back(0.0);  // Not defined, could be computed from supplied spectrum
+  m_Tp.push_back(0.0);  // Not defined, could be computed from supplied spectrum
+  m_beta.push_back(beta);
+  Eigen::VectorXd tmp_array(n_phases);  // Create array and push a copy and put a copy in each relevant std::vector
+  m_omega.push_back(tmp_array);
+  m_k.push_back(tmp_array);
+  m_phases.push_back(tmp_array);
+  m_Spectrum.push_back(tmp_array);
+  m_A.push_back(tmp_array);
 
   double d_freq = MAX_FREQ / n_phases;
   Eigen::VectorXd f;
   f.resize(n_phases);
 
-  for (int i = 0; i < m_k.size(); i++) {
+  for (int i = 0; i < m_k[NumWaveComponents].size(); i++) {
     f(i) = d_freq * (i + 1) + (0.25*d_freq*(std::rand()-RAND_MAX/2))/(RAND_MAX/2);
-    m_omega(i) = 2*M_PI*f(i);
-    m_k(i) = m_omega(i) * m_omega(i) / m_grav;
-    m_Spectrum(i) = CustomSpectrum(f(i)); //Interpolate from supplied spectrum
+    m_omega[NumWaveComponents](i) = 2*M_PI*f(i);
+    m_k[NumWaveComponents](i) = m_omega[NumWaveComponents](i) * m_omega[NumWaveComponents](i) / m_grav;
+    m_Spectrum[NumWaveComponents](i) = CustomSpectrum(f(i)); //Interpolate from supplied spectrum
     if(i == 0)
-      m_A(i) = sqrt(2.0 * f(0) * m_Spectrum(i));  // Precompute components once here.
+      m_A[NumWaveComponents](i) = sqrt(2.0 * f(0) * m_Spectrum[NumWaveComponents](i));  // Precompute components once here.
     else
-      m_A(i) = sqrt(2.0 * (f(i)-f(i-1)) * m_Spectrum(i));  // Precompute components once here.
-    m_phases(i) = (2 * M_PI * std::rand()) / RAND_MAX;
+      m_A[NumWaveComponents](i) = sqrt(2.0 * (f(i)-f(i-1)) * m_Spectrum[NumWaveComponents](i));  // Precompute components once here.
+    m_phases[NumWaveComponents](i) = (2 * M_PI * std::rand()) / RAND_MAX;
   }
+  NumWaveComponents++;  // Adding a wave component
 }
 
 std::ostream & operator<<(std::ostream & out, const LinearIncidentWave & IncWave)
 {
   // Since operator<< is a friend of the LinearIncidentWave class, we can access members directly.
-  switch (IncWave.m_SpectrumType) {
+  std::cout << "# IncidentWave consists of " << IncWave.NumWaveComponents << " Components" << std::endl;
+  for(int n = 0; n< IncWave.NumWaveComponents;n++)
+  {
+  switch (IncWave.m_SpectrumType[IncWave.NumWaveComponents]) {
     case WaveSpectrumType::MonoChromatic:
       std::cout << "# IncidentWave Type = Mono-Chromatic" << std::endl;
-      std::cout << "# Amplitude = " << IncWave.m_Hs / 2 << std::endl;
-      std::cout << "# Period = " << IncWave.m_Tp << std::endl;
-      std::cout << "# Num Phases = " << IncWave.m_Spectrum.size() << std::endl;
-      std::cout << "# Wave Freq = " << IncWave.m_omega.transpose() << std::endl;
-      std::cout << "# Wave Numbers = " << IncWave.m_k.transpose() << std::endl;
-      std::cout << "# Phases = " << IncWave.m_phases.transpose() << std::endl;
-      std::cout << "# Component Amplitudes = " << IncWave.m_A.transpose() << std::endl;
+      std::cout << "# Amplitude = " << IncWave.m_Hs[n] / 2 << std::endl;
+      std::cout << "# Period = " << IncWave.m_Tp[n] << std::endl;
+      std::cout << "# Num Phases = " << IncWave.m_Spectrum[n].size() << std::endl;
+      std::cout << "# Wave Freq = " << IncWave.m_omega[n].transpose() << std::endl;
+      std::cout << "# Wave Numbers = " << IncWave.m_k[n].transpose() << std::endl;
+      std::cout << "# Phases = " << IncWave.m_phases[n].transpose() << std::endl;
+      std::cout << "# Component Amplitudes = " << IncWave.m_A[n].transpose() << std::endl;
       break;
     case WaveSpectrumType::PiersonMoskowitz:
       std::cout << "# IncidentWave Type = Pierson Moskowitz" << std::endl;
-      std::cout << "# Hs = " << IncWave.m_Hs << std::endl;
-      std::cout << "# Tp = " << IncWave.m_Tp << std::endl;
-      std::cout << "# Num Phases = " << IncWave.m_Spectrum.size() << std::endl;
-      std::cout << "# Wave Freq = " << IncWave.m_omega.transpose() << std::endl;
-      std::cout << "# Wave Numbers = " << IncWave.m_k.transpose() << std::endl;
-      std::cout << "# Phases = " << IncWave.m_phases.transpose() << std::endl;
-      std::cout << "# Spectrum = " << IncWave.m_Spectrum.transpose() << std::endl;
-      std::cout << "# Component Amplitudes = " << IncWave.m_A.transpose() << std::endl;
+      std::cout << "# Hs = " << IncWave.m_Hs[n] << std::endl;
+      std::cout << "# Tp = " << IncWave.m_Tp[n] << std::endl;
+      std::cout << "# Num Phases = " << IncWave.m_Spectrum[n].size() << std::endl;
+      std::cout << "# Wave Freq = " << IncWave.m_omega[n].transpose() << std::endl;
+      std::cout << "# Wave Numbers = " << IncWave.m_k[n].transpose() << std::endl;
+      std::cout << "# Phases = " << IncWave.m_phases[n].transpose() << std::endl;
+      std::cout << "# Spectrum = " << IncWave.m_Spectrum[n].transpose() << std::endl;
+      std::cout << "# Component Amplitudes = " << IncWave.m_A[n].transpose() << std::endl;
       break;
     case WaveSpectrumType::Bretschneider:
       std::cout << "# IncidentWave Type = Bretschneider" << std::endl;
-      std::cout << "# Hs = " << IncWave.m_Hs << std::endl;
-      std::cout << "# Tp = " << IncWave.m_Tp << std::endl;
-      std::cout << "# Num Phases = " << IncWave.m_Spectrum.size() << std::endl;
-      std::cout << "# Wave Freq = " << IncWave.m_omega.transpose() << std::endl;
-      std::cout << "# Wave Numbers = " << IncWave.m_k.transpose() << std::endl;
-      std::cout << "# Phases = " << IncWave.m_phases.transpose() << std::endl;
-      std::cout << "# Spectrum = " << IncWave.m_Spectrum.transpose() << std::endl;
-      std::cout << "# Component Amplitudes = " << IncWave.m_A.transpose() << std::endl;
+      std::cout << "# Hs = " << IncWave.m_Hs[n] << std::endl;
+      std::cout << "# Tp = " << IncWave.m_Tp[n] << std::endl;
+      std::cout << "# Num Phases = " << IncWave.m_Spectrum[n].size() << std::endl;
+      std::cout << "# Wave Freq = " << IncWave.m_omega[n].transpose() << std::endl;
+      std::cout << "# Wave Numbers = " << IncWave.m_k[n].transpose() << std::endl;
+      std::cout << "# Phases = " << IncWave.m_phases[n].transpose() << std::endl;
+      std::cout << "# Spectrum = " << IncWave.m_Spectrum[n].transpose() << std::endl;
+      std::cout << "# Component Amplitudes = " << IncWave.m_A[n].transpose() << std::endl;
       break;
     case WaveSpectrumType::Custom:
       std::cout << "# IncidentWave Type = Custom Spectrum";
-      std::cout << "# Num Phases = " << IncWave.m_Spectrum.size() << std::endl;
-      std::cout << "# Wave Freq = " << IncWave.m_omega.transpose() << std::endl;
-      std::cout << "# Wave Numbers = " << IncWave.m_k.transpose() << std::endl;
-      std::cout << "# Phases = " << IncWave.m_phases.transpose() << std::endl;
-      std::cout << "# Spectrum = " << IncWave.m_Spectrum.transpose() << std::endl;
-      std::cout << "# Component Amplitudes = " << IncWave.m_A.transpose() << std::endl;
+      std::cout << "# Num Phases = " << IncWave.m_Spectrum[n].size() << std::endl;
+      std::cout << "# Wave Freq = " << IncWave.m_omega[n].transpose() << std::endl;
+      std::cout << "# Wave Numbers = " << IncWave.m_k[n].transpose() << std::endl;
+      std::cout << "# Phases = " << IncWave.m_phases[n].transpose() << std::endl;
+      std::cout << "# Spectrum = " << IncWave.m_Spectrum[n].transpose() << std::endl;
+      std::cout << "# Component Amplitudes = " << IncWave.m_A[n].transpose() << std::endl;
       break;
+    }
   }
   return out;  // return std::ostream so we can chain calls to operator<<
 }
 
 double LinearIncidentWave::eta(double x, double y, double t) const
 {
-  double xx = x * cos(m_beta) + y * sin(m_beta);
-
   double eta = 0;
-  for (int i = 0; i < m_A.size(); i++) {
-    eta = eta + m_A(i) * cos(m_k(i) * xx - m_omega(i) * t + m_phases(i));
+  for(int n = 0; n< NumWaveComponents;n++)
+  {
+    double xx = x * cos(m_beta[n]) + y * sin(m_beta[n]);
+
+    for (int i = 0; i < m_A[n].size(); i++) {
+      eta +=  m_A[n](i) * cos(m_k[n](i) * xx - m_omega[n](i) * t + m_phases[n](i));
+    }
   }
   return eta;
 
@@ -270,55 +285,58 @@ double LinearIncidentWave::eta(double x, double y, double t,
                                double *deta_dx, double *deta_dy,
                                double *u_east, double *v_north) const
 {
-  double xx = x * cos(m_beta) + y * sin(m_beta);
-
   double eta = 0.0;
   double deta_dxx = 0.0;
+  for(int n = 0; n< NumWaveComponents;n++)
+  {
+    double xx = x * cos(m_beta[n]) + y * sin(m_beta[n]);
 
-  // Eulerian along-wave contribution
-  double u_along = 0.0;
+    // Eulerian along-wave contribution
+    double u_along = 0.0;
 
-  for (int i = 0; i < m_A.size(); i++) {
-    double k = m_k(i);
-    double omega = m_omega(i);
-    double a = m_A(i);
-    double phase = m_phases(i);
+    for (int i = 0; i < m_A[n].size(); i++) {
+      double k = m_k[n](i);
+      double omega = m_omega[n](i);
+      double a = m_A[n](i);
+      double phase = m_phases[n](i);
 
-    double arg = k * xx - omega * t + phase;
-    double cosarg = cos(arg);
-    double sinarg = sin(arg);
+      double arg = k * xx - omega * t + phase;
+      double cosarg = cos(arg);
+      double sinarg = sin(arg);
 
-    // freesurface heave
-    eta += a * cosarg;
+      // freesurface heave
+      eta += a * cosarg;
+
+      // water plane slope
+      deta_dxx -= k * a * sinarg;
+
+      // Eulerian along-wave surface velocity (assume deep water)
+      // can just use omega directly since deep water dispersion w^2 = gk
+      u_along += a * omega * cosarg;
+    }
 
     // water plane slope
-    deta_dxx -= k * a * sinarg;
+    if (deta_dx) *deta_dx += deta_dxx*cos(m_beta[n]);  // deta/dx
+    if (deta_dy) *deta_dy += deta_dxx*sin(m_beta[n]);  // deta/dy
 
-    // Eulerian along-wave surface velocity (assume deep water)
-    // can just use omega directly since deep water dispersion w^2 = gk
-    u_along += a * omega * cosarg;
+    // u/v Eulerian surface velocities
+    if (u_east) *u_east += u_along * cos(m_beta[n]);
+    if (v_north) *v_north += u_along * sin(m_beta[n]);
   }
-
-  // water plane slope
-  if (deta_dx) *deta_dx = deta_dxx*cos(m_beta);  // deta/dx
-  if (deta_dy) *deta_dy = deta_dxx*sin(m_beta);  // deta/dy
-
-  // u/v Eulerian surface velocities
-  if (u_east) *u_east = u_along * cos(m_beta);
-  if (v_north) *v_north = u_along * sin(m_beta);
-
   return eta;
 }
 
 double LinearIncidentWave::etadot(double x, double y, double t) const
 {
-  double xx = x * cos(m_beta) + y * sin(m_beta);
-
   double etadot = 0;
-  for (int i = 0; i < m_A.size(); i++) {
-    etadot = etadot + m_omega(i) * m_A(i) * sin(m_k(i) * xx - m_omega(i) * t + m_phases(i));
-  }
+  for(int n = 0; n< NumWaveComponents;n++)
+  {
+    double xx = x * cos(m_beta[n]) + y * sin(m_beta[n]);
 
+    for (int i = 0; i < m_A[n].size(); i++) {
+      etadot += m_omega[n](i) * m_A[n](i) * sin(m_k[n](i) * xx - m_omega[n](i) * t + m_phases[n](i));
+    }
+  }
   return etadot;
 }
 

--- a/src/LinearIncidentWave.cpp
+++ b/src/LinearIncidentWave.cpp
@@ -320,18 +320,22 @@ double LinearIncidentWave::eta(double x, double y, double t,
                                double *u_east, double *v_north) const
 {
   double eta = 0.0;
-  double deta_dxx = 0.0;
   if (deta_dx) *deta_dx = 0.0;
   if (deta_dy) *deta_dy = 0.0;
   if (u_east) *u_east = 0.0;
   if (v_north) *v_north = 0.0;
 
-  // Eulerian along-wave contribution
-  double u_along = 0.0;
-
   for(int n = 0; n< NumWaveComponents;n++)
   {
     double xx = x * cos(m_beta[n]) + y * sin(m_beta[n]);
+
+    // Per-direction-component slope / along-wave velocity contributions.
+    // These must be reset for each directional component before projecting
+    // into global East/North. Accumulating them across `n` and then applying
+    // the current component heading mixes previous sectors into the wrong
+    // direction, which especially corrupts multi-sector directional seas.
+    double deta_dxx = 0.0;
+    double u_along = 0.0;
 
 
     for (int i = 0; i < m_A[n].size(); i++) {

--- a/src/LinearIncidentWave.cpp
+++ b/src/LinearIncidentWave.cpp
@@ -38,7 +38,7 @@ LinearIncidentWave::LinearIncidentWave(unsigned int seed) : m_grav(9.81), m_rho(
 }
 
 /// \brief Sets seed to specified value
-void LinearIncidentWave::SetSeed(unsigned int seed) 
+void LinearIncidentWave::SetSeed(unsigned int seed)
 {
   if(seed == 0)
     std::srand(time(0));
@@ -79,7 +79,7 @@ void LinearIncidentWave::SetToBretschneiderSpectrumWithCos2Spreading(double Hs, 
   SetToBretschneiderSpectrumWithCos2Spreading(Hs, Tp, beta_0, DEFAULT_N_PHASES, spreading_factor, n_sectors);
 }
 
-void LinearIncidentWave::SetToBretschneiderSpectrumWithCos2Spreading(double Hs, double Tp, double beta_0, int n_phases,int spreading_factor, int n_sectors)
+void LinearIncidentWave::SetToBretschneiderSpectrumWithCos2Spreading(double Hs, double Tp, double beta_0, int n_phases, int spreading_factor, int n_sectors)
 {
 double d_beta = 2.0*M_PI/n_sectors;
 for(int n = 1; n < n_sectors; n++) // start with n = 1 b/c the reciprocal heading wave is of identically zero  (cos(pi/2) = 0)
@@ -130,7 +130,7 @@ void LinearIncidentWave::SetToPiersonMoskowitzSpectrumWithCos2Spreading(double H
   SetToPiersonMoskowitzSpectrumWithCos2Spreading(Hs, beta_0, DEFAULT_N_PHASES, spreading_factor, n_sectors);
 }
 
-void LinearIncidentWave::SetToPiersonMoskowitzSpectrumWithCos2Spreading(double Hs, double beta_0, int n_phases,int spreading_factor, int n_sectors)
+void LinearIncidentWave::SetToPiersonMoskowitzSpectrumWithCos2Spreading(double Hs, double beta_0, int n_phases, int spreading_factor, int n_sectors)
 {
 double d_beta = 2.0*M_PI/n_sectors;
 for(int n = 1; n < n_sectors; n++) // start with n = 1 b/c the reciprocal heading wave is of identically zero  (cos(pi/2) = 0)

--- a/src/LinearIncidentWave.cpp
+++ b/src/LinearIncidentWave.cpp
@@ -287,12 +287,18 @@ double LinearIncidentWave::eta(double x, double y, double t,
 {
   double eta = 0.0;
   double deta_dxx = 0.0;
+  if (deta_dx) *deta_dx = 0.0;
+  if (deta_dy) *deta_dy = 0.0;
+  if (u_east) *u_east = 0.0;
+  if (v_north) *v_north = 0.0;
+
+  // Eulerian along-wave contribution
+  double u_along = 0.0;
+
   for(int n = 0; n< NumWaveComponents;n++)
   {
     double xx = x * cos(m_beta[n]) + y * sin(m_beta[n]);
 
-    // Eulerian along-wave contribution
-    double u_along = 0.0;
 
     for (int i = 0; i < m_A[n].size(); i++) {
       double k = m_k[n](i);

--- a/src/pybind11/bindings.cpp
+++ b/src/pybind11/bindings.cpp
@@ -40,11 +40,31 @@ PYBIND11_MODULE(fshd, m) {
                      double, double, double, int
                  >(&LinearIncidentWave::SetToBretschneiderSpectrum),
              py::arg("Hs"), py::arg("Tp"), py::arg("beta"), py::arg("n_phases")=DEFAULT_N_PHASES)
+        .def("SetToBretschneiderSpectrumWithCos2Spreading",
+             [](LinearIncidentWave& self,
+                double Hs, double Tp, double beta,
+                int spreading_factor, int n_sectors, int n_phases) {
+                 return self.SetToBretschneiderSpectrumWithCos2Spreading(
+                     Hs, Tp, beta, n_phases, spreading_factor, n_sectors);
+             },
+             py::arg("Hs"), py::arg("Tp"), py::arg("beta"),
+             py::arg("spreading_factor"), py::arg("n_sectors"),
+             py::arg("n_phases") = DEFAULT_N_PHASES)
         .def("SetToPiersonMoskowitzSpectrum",
              py::overload_cast<
                      double, double, int
                  >(&LinearIncidentWave::SetToPiersonMoskowitzSpectrum),
              py::arg("Hs"), py::arg("beta"), py::arg("n_phases")=DEFAULT_N_PHASES)
+        .def("SetToPiersonMoskowitzSpectrumWithCos2Spreading",
+             [](LinearIncidentWave& self,
+                double Hs, double beta,
+                int spreading_factor, int n_sectors, int n_phases) {
+                 return self.SetToBretschneiderSpectrumWithCos2Spreading(
+                     Hs, beta, n_phases, spreading_factor, n_sectors);
+             },
+             py::arg("Hs"), py::arg("beta"),
+             py::arg("spreading_factor"), py::arg("n_sectors"),
+             py::arg("n_phases") = DEFAULT_N_PHASES)
         .def("SetToCustomSpectrum",
              py::overload_cast<
                      std::vector<double>, std::vector<double>, double, int

--- a/src/pybind11/bindings.cpp
+++ b/src/pybind11/bindings.cpp
@@ -59,7 +59,7 @@ PYBIND11_MODULE(fshd, m) {
              [](LinearIncidentWave& self,
                 double Hs, double beta,
                 int spreading_factor, int n_sectors, int n_phases) {
-                 return self.SetToBretschneiderSpectrumWithCos2Spreading(
+                 return self.SetToPiersonMoskowitzSpectrumWithCos2Spreading(
                      Hs, beta, n_phases, spreading_factor, n_sectors);
              },
              py::arg("Hs"), py::arg("beta"),
@@ -138,6 +138,7 @@ PYBIND11_MODULE(fshd, m) {
              })
 
         .def_readonly("m_Tp", &LinearIncidentWave::m_Tp)
+        .def_readonly("m_Hs", &LinearIncidentWave::m_Hs)
         .def_readonly("m_omega", &LinearIncidentWave::m_omega)
         .def_readonly("m_A", &LinearIncidentWave::m_A);
 


### PR DESCRIPTION
Added example code that plots the wave elevation and surface velocity vectors computed by "LinearIncidentWave".  After building execute as "./IncidentWaveDirectionExample -h" to see command line options.  Plot is created by the executable, but isn't interactive, to get an interactive version you can rotate with the mouse etc, plot independently in gnuplot from the command line using the gnuplot commands the example prints out.